### PR TITLE
Add instructions for how to build on linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 # SW102_Display
+
+## How to build on Windows
+
+TBD
+
+## How to build on Linux
+
+* Extract https://launchpad.net/gcc-arm-embedded/4.9/4.9-2015-q3-update/+download/gcc-arm-none-eabi-4_9-2015q3-20150921-linux.tar.bz2 into /usr/local/gcc-arm-none-eabi-4_9-2015q3.
+* Run "make"


### PR DESCRIPTION
Fix #1.  The initial makefile made me think it might be Windowish only
because of the backslash paths, but I guess not.  Everything builds
basically fine on linux, so added some small instruction on how to setup
the dev environment.  Later the openocd stuff might need tweaking though.